### PR TITLE
Update NeighbouringFileNavigator.ts to remove md requirement

### DIFF
--- a/src/NeighbouringFileNavigator.ts
+++ b/src/NeighbouringFileNavigator.ts
@@ -4,7 +4,7 @@ export default class NeighbouringFileNavigator {
 
 	public static getNeighbouringFiles(file: TFile) {
 		const files = file?.parent?.children;
-		const filteredFiles = files?.filter(f => f instanceof TFile && f.extension === 'md') as TFile[];
+		const filteredFiles = files?.filter(f => f instanceof TFile) as TFile[];
 		const sortedFiles = filteredFiles?.sort((a, b) =>
 			a.basename.localeCompare(b.basename, undefined, {
 				numeric: true,


### PR DESCRIPTION
Want to be able to switch through pdf files